### PR TITLE
chore: Configure Docker build context exclusions for backend service

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,41 @@
+# Git
+.git
+.gitignore
+
+# Documentation
+*.md
+docs/
+
+# Testing
+*_test.go
+*.test
+coverage.txt
+coverage.html
+
+# Development
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Build artifacts
+api
+*.exe
+*.dll
+*.so
+*.dylib
+
+# Temporary files
+tmp/
+temp/
+*.tmp
+*.temp
+
+# Mock files
+mock/
+mocks/


### PR DESCRIPTION
#comment Establish comprehensive .dockerignore file to exclude development artifacts, testing files, documentation, and OS-specific files from Docker build context, reducing image size and improving build performance

Affected: backend/.dockerignore